### PR TITLE
bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: projections
 Title: Project Future Case Incidence
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")), 
     person("Pierre", "Nouvellet", email = "p.nouvellet@imperial.ac.uk", role = c("aut")), 
     person("Sangeeta", "Bhatia", role = "ctb", email = "sangeetabhatia03@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# projections 0.3.2
+
+- A bug in `project()` where R was being resampled recursively was fixed
+  (#11, @jarvisc1; #12, @zkamvar)
+
 # projections 0.3.1
 
  - `get_dates()` now inherits the generic `get_dates()` from incidence


### PR DESCRIPTION
since #11 was a notable bug, I think it's only appropriate to bump the minor version to make sure the change is felt. 

This also serves as a test to make sure I can't push to master when I have mandatory travis checks turned on.