### PR TITLE
Si warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: projections
 Title: Project Future Case Incidence
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: 
     c(person(given = "Thibaut",
              family = "Jombart",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# projections 0.5.3
+
+## Fixes and improvements
+
+- harmonise si definition with EpiEstim.
+
 # projections 0.5.2
 
 ## Fixes and improvements

--- a/R/project.R
+++ b/R/project.R
@@ -7,7 +7,7 @@
 #' @export
 #'
 #' @author Pierre Nouvellet (original model), Thibaut Jombart (bulk of the
-#'   code), Sangeeta Bhatia (Negative Binomial model), Stephane Ghozzi (bug fixes 
+#'   code), Sangeeta Bhatia (Negative Binomial model), Stephane Ghozzi (bug fixes
 #'   time varying R)
 #'
 #' @param x An \code{incidence} object containing daily incidence; other time
@@ -118,12 +118,12 @@
 #'                   n_sim = 100)
 #' plot(proj_4)
 #'
-#' 
+#'
 #' ## time-varying R, 2 periods, separate distributions of R for each period
 #' set.seed(1)
 #' R_period_1 <- runif(100, min = 1.1, max = 3)
 #' R_period_2 <- runif(100, min = 0.6, max = .9)
-#' 
+#'
 #' proj_5 <- project(i,
 #'                   R = list(R_period_1, R_period_2),
 #'                   si = si,
@@ -131,7 +131,7 @@
 #'                   time_change = 20,
 #'                   n_sim = 100)
 #' plot(proj_5)
-#' 
+#'
 #' }
 #'
 
@@ -196,7 +196,7 @@ project <- function(x, R, si, n_sim = 100, n_days = 7,
   n_dates_x <- nrow(incidence::get_counts(x))
   t_max <- n_days + n_dates_x - 1
 
-  # si is the the pmf of the serial interval starting at day 1, i.e. one day 
+  # si is the the pmf of the serial interval starting at day 1, i.e. one day
   # after symptom onset
   if (inherits(si, "distcrete")) {
     if (as.integer(si$interval) != 1L) {
@@ -217,6 +217,12 @@ project <- function(x, R, si, n_sim = 100, n_days = 7,
     si <- si$d(1:t_max)
     si <- si / sum(si)
   } else {
+    if(si[1] == 0) {
+      msg1 <- "si[1] is 0. Did you accidentally input the serial interval"
+      msg2 <- "distribution starting at time 0 instead of 1? If so, rerun with"
+      msg3 <- "a new si where si[1] is the PMF for serial interval of 1."
+      warning(paste(msg1, msg2, msg3))
+    }
     si <- si / sum(si)
     si <- c(si, rep(0, t_max-1))
   }
@@ -233,9 +239,9 @@ project <- function(x, R, si, n_sim = 100, n_days = 7,
   ## forces of infection. The individual force of infection is computed as the
   ## R0 multiplied by the pmf of the serial interval si for the corresponding day:
 
-  ## lambda_{i,t} = R0(t_i) si(t - t_i) 
+  ## lambda_{i,t} = R0(t_i) si(t - t_i)
 
-  ## where 'si' is the PMF of the serial interval, 'ws' it's reverse, and 
+  ## where 'si' is the PMF of the serial interval, 'ws' it's reverse, and
   ## 't_i' is the date of onset of case 'i'.
 
 
@@ -277,7 +283,7 @@ project <- function(x, R, si, n_sim = 100, n_days = 7,
   ## On the drawing of R values: either these are constant within simulations,
   ## so drawn once for all simulations, or they need drawing at every time step
   ## for every simulations.
-  
+
   ## On the handling of reporting: reporting first affects the force of
   ## infection lambda, with the underlying assumption that the true epicurve
   ## multiplied by the (constant) reporting results in the observed one. Then,
@@ -296,7 +302,7 @@ project <- function(x, R, si, n_sim = 100, n_days = 7,
       R_time_period <- sample_(R[[time_period]], n_sim, replace = TRUE)
       period_duration <- time_change_boundaries[time_period+1] - time_change_boundaries[time_period]
       current_R_t <- do.call(
-        'rbind', 
+        'rbind',
         replicate(period_duration, R_time_period, simplify = FALSE)
       )
       R_t <- rbind(R_t, current_R_t)

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -149,6 +149,6 @@ plot(proj_5)
 }
 \author{
 Pierre Nouvellet (original model), Thibaut Jombart (bulk of the
-  code), Sangeeta Bhatia (Negative Binomial model), Stephane Ghozzi (bug fixes 
+  code), Sangeeta Bhatia (Negative Binomial model), Stephane Ghozzi (bug fixes
   time varying R)
 }

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -2,7 +2,7 @@ test_that("Projections can be performed for a single day", {
   i <- incidence::incidence(as.Date('2020-01-23'))
   si <- c(0.2, 0.5, 0.2, 0.1)
   R0 <- 2
-  
+
   p <- project(x = i,
                si = si,
                R = R0,
@@ -23,7 +23,7 @@ test_that("Projections can be performed for a single day", {
   i <- incidence::incidence(as.Date('2020-01-23'))
   si <- c(0.2, 0.5, 0.2, 0.1)
   R0 <- 2
-  
+
   p <- project(x = i,
                si = si,
                R = R0,
@@ -45,7 +45,7 @@ test_that("Projections can be performed for a single day and single simulation",
   i <- incidence::incidence(as.Date('2020-01-23'))
   si <- c(0.2, 0.5, 0.2, 0.1)
   R0 <- 2
-  
+
   p <- project(x = i,
                si = si,
                R = R0,
@@ -126,7 +126,7 @@ test_that("Errors are thrown when they should", {
   expect_error(project(i, si = si, time_change = 2, R = matrix(1.2)),
                msg,
                fixed = TRUE)
-  
+
 })
 
 
@@ -149,7 +149,7 @@ test_that("Test against reference results - Poisson model", {
   set.seed(1)
   pred_1 <- project(i, runif(100, 0.8, 1.9), si, n_days = 30)
   expect_snapshot_value(pred_1, style = "serialize")
-  
+
 
   ## time-varying R (fixed within time windows)
   set.seed(1)
@@ -255,15 +255,15 @@ test_that("Test against reference results - NegBin model", {
 
 
 test_that("Test R_fix_within", {
-  
+
   ## The rationale of this test is to check that the variance of trajectories
   ## when fixing R within a given simulation is larger than when drawing
   ## systematically from the distribution. On the provided example, fixing R
   ## will lead to many more trajectories growing fast, and greater average
   ## incidence (> x10 for the last time steps).
-  
+
   skip_on_cran()
-  
+
   ## simulate basic epicurve
   dat <- c(0, 2, 2, 3, 3, 5, 5, 5, 6, 6, 6, 6)
   i <- incidence::incidence(dat)
@@ -282,5 +282,27 @@ test_that("Test R_fix_within", {
                      n_sim = 1000,
                      R_fix_within = TRUE)
   expect_true(all(tail(rowSums(x_fixed) / rowSums(x_base), 5) > 10))
-  
+
+})
+
+
+
+
+
+test_that("Projections throw warning if si[1] = 0", {
+  i <- incidence::incidence(as.Date('2020-01-23'))
+  si <- c(0, 0.2, 0.5, 0.2, 0.1)
+  R0 <- 2
+
+  msg <- "si[1] is 0. Did you accidentally input the serial interval"
+
+  expect_warning(project(x = i,
+               si = si,
+               R = R0,
+               n_sim = 2,
+               R_fix_within = TRUE,
+               n_days = 1,
+               model = "poisson"),
+               msg, fixed = TRUE)
+
 })


### PR DESCRIPTION
Adding a warning to safeguard agains using the wrong specification of the serial interval (will help smooth transition between EpiEstim and projections). 

I get a failing check locally due to the functions defined in the test files not being recognised: 
`could not find function "expect_snapshot_value"`
`could not find function "expect_snapshot_file"`
I don't think these are caused by my changes and I don't know how to solve so just mentioning here for @thibautjombart to double check